### PR TITLE
Fix hero height to account for header

### DIFF
--- a/assets/rave-custom.css
+++ b/assets/rave-custom.css
@@ -324,9 +324,7 @@ body {
     grid-column: 2 / 3;
     justify-self: center;
     /* Center the logo */
-    /* Added to nudge the logo slightly to the left for better visual alignment */
-    transform: translateX(-10px);
-    /* Adjust this value as needed */
+
   }
 
   header.header--middle-center>nav.header__inline-menu--right {
@@ -628,10 +626,16 @@ body {
 /* == MAIN HERO SECTION == */
 .main-hero {
   width: 100%;
-  height: 100vh;
-  /* Full viewport height */
+  height: calc(100vh - var(--header-height, 0px));
+  /* Full viewport height minus header */
   overflow: hidden;
   position: relative;
+}
+
+.main-hero__link {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .main-hero__image,
@@ -645,10 +649,12 @@ body {
 }
 
 .main-hero__video-wrapper {
-  position: relative;
-  padding-bottom: 56.25%;
-  /* 16:9 aspect ratio */
-  height: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
   overflow: hidden;
 }
 
@@ -678,7 +684,7 @@ body {
 /* Responsive adjustments if needed, for example: */
 @media (max-width: 749px) {
   .main-hero {
-    height: 80vh;
+    height: calc(80vh - var(--header-height, 0px));
   }
 }
 


### PR DESCRIPTION
## Summary
- remove logo shift transform in the header layout
- keep hero at full viewport height minus the sticky header

## Testing
- `git status --short`
